### PR TITLE
Fix broken error message

### DIFF
--- a/tasks/static-i18n.coffee
+++ b/tasks/static-i18n.coffee
@@ -32,6 +32,7 @@ module.exports = (grunt) ->
 
     (staticI18n.processDir options.baseDir, options)
         .then(done).catch((err) ->
-            grunt.log.error 'Failed to compile: #{err}'
+            err.message = 'Failed to compile '  + err.message;
+            grunt.log.error err
             grunt.fail.warn 'i18n task failed'
         )


### PR DESCRIPTION
:wave:  The current log is broken, it doesn't log the error message.

Current error:

```sh
Running "i18n:dist" (i18n) task                                      
>> Failed to compile: #{err}                                         
Warning: i18n task failed Use --force to continue.                   
                                                                     
Aborted due to warnings.                                             
```

With this fix:

![Screenshot from 2020-02-17 16-04-20](https://user-images.githubusercontent.com/713283/74665186-77d02100-519f-11ea-87df-e57112dc2d94.png)
